### PR TITLE
Update to 0.0.5 of the three-gpu-pathtracer.

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "^4.3.1",
     "react-scripts": "5.0.1",
-    "three": "^0.140.0",
+    "three": "^0.141.0",
     "three-custom-shader-material": "^3.3.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -67,15 +67,15 @@
     "rollup": "^2.70.2",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "rollup-plugin-terser": "^7.0.2",
-    "three": "^0.140.0",
+    "three": "^0.141.0",
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "three-gpu-pathtracer": "^0.0.2"
+    "three-gpu-pathtracer": "^0.0.5"
   },
   "peerDependencies": {
     "@react-three/fiber": ">=8.0",
     "react": ">=18.0",
-    "three": ">=0.138"
+    "three": ">=0.141.0"
   }
 }

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -1,4 +1,4 @@
-rm -rf ./node_modeules ./yarn.lock
+rm -rf ./node_modules ./yarn.lock
 yarn
 
 cd dist
@@ -17,7 +17,7 @@ cd ../../../
 
 for d in ./examples/* ; do
     cd $d
-    rm -rf ./node_modeules ./yarn.lock
+    rm -rf ./node_modules ./yarn.lock
     yarn
 
     yarn link @react-three/gpu-pathtracer

--- a/src/API.ts
+++ b/src/API.ts
@@ -22,6 +22,8 @@ export function API(): PathtracerAPI {
     const generator = new DynamicPathTracingSceneGenerator(scene)
     ptRenderer.camera = camera
     ptRenderer.material = ptMaterial
+    ptRenderer.alpha = true;
+    ptRenderer.material.setDefine("FEATURE_MIS", 4);
 
     ptRenderer.__r3fState = {
       initialized: false,
@@ -32,7 +34,7 @@ export function API(): PathtracerAPI {
     const fsQuad = new FullScreenQuad(
       new THREE.MeshBasicMaterial({
         map: ptRenderer.target.texture,
-        transparent: true,
+        blending: THREE.CustomBlending,
       })
     )
 
@@ -61,7 +63,6 @@ export function API(): PathtracerAPI {
     ptMaterial.textures.setTextures(gl, 2048, 2048, textures)
     ptMaterial.materials.updateFrom(materials, textures)
 
-    ptRenderer.material.setDefine('MATERIAL_LENGTH', materials.length)
     ptRenderer.__r3fState.initialized = true
   }, [])
 

--- a/src/Pathtracer.tsx
+++ b/src/Pathtracer.tsx
@@ -50,7 +50,7 @@ export function Pathtracer({
     const dpr = viewport.dpr
 
     api.renderer.reset()
-    api.renderer.target.setSize(w * scale * dpr, h * scale * dpr)
+    api.renderer.setSize(w * scale * dpr, h * scale * dpr)
   }, [viewport, size, resolutionScale])
 
   useFrame(

--- a/src/core/useBackground.ts
+++ b/src/core/useBackground.ts
@@ -35,7 +35,7 @@ export default function useBackground(api: PathtracerAPI, background: Partial<Pa
       pmremGenerator.compileCubemapShader()
 
       const envMap = pmremGenerator.fromEquirectangular(scene.environment)
-      api.renderer.material.environmentMap = envMap.texture
+      api.renderer.material.envMapInfo.updateFrom(scene.environment)
     }
   }, [scene.environment])
 }


### PR DESCRIPTION
The purpose of this PR is to make some minor changes so that the react wrapper works with the latest three-gpu-pathtracer (0.0.5).
There have been some changes to how the environment map is handled which I haven't fleshed out here.